### PR TITLE
Optionally generate document urls with trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ environments:
 				enabled: false
 ```
 
+### trailingSlashes
+
+Enable to generate `document.url`s like `'/beep/'` instead of `/beep`.  Defaults to `false`.
+
 
 ## History
 You can discover the history inside the `History.md` file

--- a/src/cleanurls.plugin.coffee
+++ b/src/cleanurls.plugin.coffee
@@ -21,22 +21,27 @@ module.exports = (BasePlugin) ->
 				</html>
 				"""
 
+			trailingSlashes: false
+
 		# Clean URLs for Document
 		cleanUrlsForDocument: (document) =>
 			# Prepare
 			url = document.get('url')
 			pathUtil = require('path')
+			trailingSlashes = @config.trailingSlashes
 
 			# Index URL
 			if /index\.html$/i.test(url)
 				relativeDirUrl = pathUtil.dirname(url)
+				if trailingSlashes and relativeDirUrl isnt '/'
+					relativeDirUrl += '/'
 				document.setUrl(relativeDirUrl)
 
 			# Create Extensionless URL
 			else if /\.html$/i.test(url)
 				relativeBaseUrl = url.replace(/\.html$/,'')
-				document.setUrl(relativeBaseUrl)
-				document.addUrl(relativeBaseUrl+'/')
+				document.setUrl(relativeBaseUrl + if trailingSlashes then '/' else '')
+				document.addUrl(relativeBaseUrl + if trailingSlashes then '' else '/')
 
 			# Done
 			document

--- a/src/cleanurls.tester.coffee
+++ b/src/cleanurls.tester.coffee
@@ -31,3 +31,18 @@ module.exports = (testers) ->
 						expectedStr = 'Welcome'
 						expect(actualStr).to.equal(expectedStr)
 						done()
+
+				test 'documents should have urls without extensions', (done) ->
+					actualUrls = tester.docpad.getCollection('documents').map (doc) -> doc.get('url')
+					expectedUrls = ['/', '/hi', '/welcome']
+					expect(actualUrls.sort()).to.deep.equal(expectedUrls)
+					done()
+
+				test 'enabling trailingSlashes should append slashes to document urls', (done) ->
+					tester.docpad.loadedPlugins.cleanurls.config.trailingSlashes = true
+					tester.docpad.action 'generate', (err) ->
+						return done(err) if err
+						actualUrls = tester.docpad.getCollection('documents').map (doc) -> doc.get('url')
+						expectedUrls = ['/', '/hi', '/welcome/']
+						expect(actualUrls.sort()).to.deep.equal(expectedUrls)
+						done()


### PR DESCRIPTION
Github pages serves `beep/index.html` from `example.com/beep/`.  Links to `/beep` will make an extra redirect round trip.  Enabling `trailingSlashes` will set `document.url` to `/beep/`, making it easier to create the right links in templates and switch link schemes per environment.
