### PR TITLE
Add skipCleanUrls metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ environments:
 
 Enable to generate `document.url`s like `'/beep/'` instead of `/beep`.  Defaults to `false`.
 
+### skipCleanUrls
+
+Add `skipCleanUrls: true` as metadata to any document that you would like to bypass the normal cleanurls processing on.  For example, you may want to bypass cleanurls processing for your 404.html.md page.
+
+```
+---
+layout: page
+title: Oops! Page Not Found
+skipCleanUrls: true
+---
+
+Oops! Page Not Found.
+
+```
 
 ## History
 [You can discover the history inside the `History.md` file](https://github.com/bevry/docpad-plugin-cleanurls/blob/master/History.md#files)

--- a/src/cleanurls.plugin.coffee
+++ b/src/cleanurls.plugin.coffee
@@ -25,6 +25,8 @@ module.exports = (BasePlugin) ->
 
 		# Clean URLs for Document
 		cleanUrlsForDocument: (document) =>
+			# skip any files that have been flagged appropriately
+			return if document.getMeta('skipCleanUrls') is true
 			# Prepare
 			url = document.get('url')
 			pathUtil = require('path')
@@ -91,7 +93,7 @@ module.exports = (BasePlugin) ->
 				# Cycle
 				collection.forEach (document) ->
 					# Check
-					return  if document.get('write') is false or document.get('ignore') is true or document.get('render') is false
+					return  if document.get('write') is false or document.get('ignore') is true or document.get('render') is false or document.getMeta('skipCleanUrls') is true
 
 					# Prepare
 					encoding = document.get('encoding')


### PR DESCRIPTION
I added the ability to skip cleanurls processing on a document-by-document basis by looking for a skipCleanUrls metadata property.  I needed this, for example, for my 404.html file which I needed to stay /404.html and didn't want it to be redirected to /404/.
