### PR TITLE
Added canonical link relationship for redirect

### DIFF
--- a/src/cleanurls.plugin.coffee
+++ b/src/cleanurls.plugin.coffee
@@ -14,6 +14,7 @@ module.exports = (BasePlugin) ->
 					<head>
 						<title>#{document.get('title') or 'Redirect'}</title>
 						<meta http-equiv="REFRESH" content="0;url=#{document.get('url')}">
+						<link rel="canonical" href="#{document.get('url')}" />
 					</head>
 					<body>
 						This page has moved. You will be automatically redirected to its new location. If you aren't forwarded to the new page, <a href="#{document.get('url')}">click here</a>.


### PR DESCRIPTION
The commit adds a link tag which suggests to search engines that they re-index the page using the destination URL.  Probably as close to a 301 (permanent) redirect you'd be able to get when only using HTML.

[Read about canonical here.](https://en.wikipedia.org/wiki/Canonical_link_element)
