### PR TITLE
Added space to http-equiv to pass W3C Validator

### DIFF
--- a/src/cleanurls.plugin.coffee
+++ b/src/cleanurls.plugin.coffee
@@ -13,7 +13,7 @@ module.exports = (BasePlugin) ->
 				<html>
 					<head>
 						<title>#{document.get('title') or 'Redirect'}</title>
-						<meta http-equiv="REFRESH" content="0;url=#{document.get('url')}">
+						<meta http-equiv="REFRESH" content="0; url=#{document.get('url')}">
 						<link rel="canonical" href="#{document.get('url')}" />
 					</head>
 					<body>

--- a/test/static/out-expected/special.html
+++ b/test/static/out-expected/special.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Special</title>
-		<meta http-equiv="REFRESH" content="0;url=/hi">
+		<meta http-equiv="REFRESH" content="0; url=/hi">
 		<link rel="canonical" href="/hi" />
 	</head>
 	<body>

--- a/test/static/out-expected/special/index.html
+++ b/test/static/out-expected/special/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Special</title>
-		<meta http-equiv="REFRESH" content="0;url=/hi">
+		<meta http-equiv="REFRESH" content="0; url=/hi">
 		<link rel="canonical" href="/hi" />
 	</head>
 	<body>

--- a/test/static/out-expected/welcome.html
+++ b/test/static/out-expected/welcome.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Redirect</title>
-		<meta http-equiv="REFRESH" content="0;url=/welcome">
+		<meta http-equiv="REFRESH" content="0; url=/welcome">
 		<link rel="canonical" href="/welcome" />
 	</head>
 	<body>


### PR DESCRIPTION
As reported in docpad/docpad-plugin-paged#16, the generated redirect pages do not pass W3C Validation because there is no space between `0;` and `url`.

Note that plugin tests that use this plugin will need to be updated to include this change in their expected output.